### PR TITLE
Display orders on stocks

### DIFF
--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,3 +1,5 @@
 class Stock < ActiveRecord::Base
+  has_many :orders
+
   validates :name, :symbol, presence: true
 end

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -2,5 +2,26 @@
 
 <h2><%= @stock.name %> (<%= @stock.symbol %>)</h2>
 
+<h3>Orders</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Buy/Sell</th>
+      <th>Price</th>
+      <th>Quantity</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @stock.orders.order(created_at: :desc).each do |order| %>
+      <tr>
+        <td><%= order.kind %></td>
+        <td><%= order.price %></td>
+        <td><%= order.quantity %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <%= link_to 'Edit', edit_stock_path(@stock) %> |
 <%= link_to 'Back', stocks_path %>

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
 RSpec.feature "Orders", type: :feature do
-  before do
+  scenario 'Place an order' do
     stock = create(:stock)
     user = create(:user)
     login_as(user, :scope => :user)
-  end
 
-  scenario 'Place on order' do
     visit orders_path
 
     click_on 'New Order'
@@ -21,5 +19,12 @@ RSpec.feature "Orders", type: :feature do
     click_on 'Create Order'
 
     expect(current_path).to eq orders_path
+  end
+
+  scenario 'Publically display orders' do
+    order = create(:buy_order, quantity: 1337)
+
+    visit stock_path(order.stock)
+    expect(page).to have_content '1337'
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe Order, kind: :model do
   it 'is valid' do
     order = build(:buy_order)
+
     expect(order).to be_valid
   end
 
@@ -14,12 +15,14 @@ RSpec.describe Order, kind: :model do
     it 'requires a kind' do
       order = build(:buy_order)
       order.kind = nil
+
       expect(order).to be_invalid
     end
 
     it 'requires a stock' do
       order = build(:buy_order)
       order.stock = nil
+
       expect(order).to be_invalid
     end
   end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Stock, type: :model do
-  it 'is vaild with a name and symbol' do
+  it 'is valid with a name and symbol' do
     subject.name = 'testname'
     subject.symbol = 'test'
   end
+
   context 'invalid conditions' do
     it 'is invalid without a name and symbol' do
       expect(subject).to be_invalid


### PR DESCRIPTION
Each stock should display the orders (and order info) on it.
Orders should be ordered in date descending order and publicly
viewable.